### PR TITLE
Update metadata for mobile compatibility

### DIFF
--- a/data/ml.mdwalters.Lemonade.desktop.in
+++ b/data/ml.mdwalters.Lemonade.desktop.in
@@ -6,3 +6,5 @@ Terminal=false
 Type=Application
 Categories=GTK;
 StartupNotify=true
+# Translators: Do NOT translate or transliterate this text (these are enum types)!
+X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
Show lemonade desktop icon on mobile devices running Phosh